### PR TITLE
Define Alternative in beans.xml

### DIFF
--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://java.sun.com/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-  <!-- empty beans.xml to activate CDI -->
+	<alternatives>
+		<class>org.cru.redegg.recording.api.NoOpParameterSanitizer</class>
+	</alternatives>
 </beans>


### PR DESCRIPTION
beans.xml needs to define the @ Alternative `NoOpParameterSanitizer` class in this archive so that a CDI app which wants to use it can find it.
