### PR TITLE
Sanitize headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Make a parameter sanitizer. This will keep sensitive data out of the error datab
                 return sanitize(parameterName, parameterValues);
             }
 
+            @Override
+            public List<String> sanitizeHeader(
+                String headerName, List<String> headerValues)
+            {
+                return sanitize(headerName, headerValues);
+            }
+
             private List<String> sanitize(String parameterName, List<String> parameterValues)
             {
                 if (parameterName.equals("secret"))

--- a/src/main/java/org/cru/redegg/recording/api/NoOpParameterSanitizer.java
+++ b/src/main/java/org/cru/redegg/recording/api/NoOpParameterSanitizer.java
@@ -27,4 +27,10 @@ public class NoOpParameterSanitizer implements ParameterSanitizer
         return parameterValues;
     }
 
+    @Override
+    public List<String> sanitizeHeader(String headerName, List<String> headerValues)
+    {
+        return headerValues;
+    }
+
 }

--- a/src/main/java/org/cru/redegg/recording/api/ParameterSanitizer.java
+++ b/src/main/java/org/cru/redegg/recording/api/ParameterSanitizer.java
@@ -16,4 +16,9 @@ public interface ParameterSanitizer
      */
     List<String> sanitizePostBodyParameter(String parameterName, List<String> parameterValues);
 
+    /**
+     * Sanitize a header
+     */
+    List<String> sanitizeHeader(String headerName, List<String> headerValues);
+
 }

--- a/src/test/java/org/cru/redegg/it/EndToEndIT.java
+++ b/src/test/java/org/cru/redegg/it/EndToEndIT.java
@@ -64,6 +64,8 @@ public class EndToEndIT
             .param("well-known-fact", "matt's a swell guy");
         Response appResponse = target
             .request()
+            .header("secret", "ssshh")
+            .header("answer-to-life-universe-and-everything", "42")
             .post(form(form));
         assertThat(appResponse.getStatus(), equalTo(500));
 
@@ -74,6 +76,8 @@ public class EndToEndIT
         assertThat(report, containsString("kablooie!"));
         assertThat(report, containsString("matt's a swell guy"));
         assertThat(report, not(containsString("letmein")));
+        assertThat(report, containsString("42"));
+        assertThat(report, not(containsString("ssshh")));
     }
 
     @Test

--- a/src/test/java/org/cru/redegg/it/TestSanitizer.java
+++ b/src/test/java/org/cru/redegg/it/TestSanitizer.java
@@ -25,6 +25,12 @@ public class TestSanitizer implements ParameterSanitizer
         return sanitize(parameterName, parameterValues);
     }
 
+    @Override
+    public List<String> sanitizeHeader(String headerName, List<String> headerValues)
+    {
+        return sanitize(headerName, headerValues);
+    }
+
     private List<String> sanitize(String parameterName, List<String> parameterValues)
     {
         if (parameterName.equals("secret"))


### PR DESCRIPTION
Add the capability to sanitize headers.

(This is needed for Wsapi, which would like to keep the Authorization header out of errbit)
