### PR TITLE
Allow preservation of input stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ entities will be completely removed.
 
 
 
+
+If your app sometimes needs to directly consume the request's http entity,
+configure or write a request matcher to identify which requests must have access to them.
+(For these requests, Red Egg will not call `ServletRequest.getParameter()` or related methods,
+which have the side-effect of making
+`ServletRequest.getInputStream()` and `ServletRequest.getReader()` unusable.)
+You can implement your own `RequestMatcher` or use one of the built-in `RequestMatchers` factories:
+
+    public class RedEggConfig
+    {
+        public
+        @Produces
+        @Default
+        @EntityStreamPreservation
+        RequestMatcher matcher = RequestMatchers.matchingPaths("/rest-api/.*");
+    }
+
+
+
 Make sure your exceptions are visible to Red Egg.  There's 3 ways (which can be combined) to accomplish this:
 
 1. Log the exception with Log4j or with java.util.logging (or make sure your framework does so),
@@ -160,7 +179,8 @@ it should look like the following:
     RedEgg.configure()
         .setParameterSanitizer(new MyCustomParameterSanitizer()) // or use the built-in NoOpParameterSanitizer
         .setEntitySanitizer(new MyCustomEntitySanitizer()) // or use the built-in NoOpEntitySanitizer
-        .setErrbitConfig(createConfig()); // see CDI section for example code
+        .setErrbitConfig(createConfig()) // see CDI section for example code
+        .setEntityStreamPreservationMatcher(createMatcher()); // see CDI section for example code
 
 Instead of injecting a `WebErrorRecorder`, look one up via the `RecorderFactory`.
 You can get the `RecorderFactory` via `RedEgg.getRecorderFactory()`.

--- a/src/main/java/org/cru/redegg/manual/Builder.java
+++ b/src/main/java/org/cru/redegg/manual/Builder.java
@@ -5,6 +5,8 @@ import org.cru.redegg.jaxrs.RecordingReaderInterceptor;
 import org.cru.redegg.recording.api.EntitySanitizer;
 import org.cru.redegg.recording.api.ParameterSanitizer;
 import org.cru.redegg.recording.api.RecorderFactory;
+import org.cru.redegg.recording.api.RequestMatcher;
+import org.cru.redegg.recording.api.RequestMatchers;
 import org.cru.redegg.recording.api.Serializer;
 import org.cru.redegg.recording.api.WebErrorRecorder;
 import org.cru.redegg.recording.gson.GsonSerializer;
@@ -56,6 +58,9 @@ public class Builder
     private final ReplaceableEntitySanitizer entitySanitizer =
         new ReplaceableEntitySanitizer(new HyperConservativeEntitySanitizer());
 
+    private final ReplaceableRequestMatcher streamPreservationMatcher = new ReplaceableRequestMatcher(
+        RequestMatchers.none());
+
     private volatile ErrbitConfig errbitConfig;
     private volatile InMemoryErrorQueue queue;
 
@@ -70,7 +75,7 @@ public class Builder
 
     ParameterCategorizer buildParameterCategorizer()
     {
-        return new ParameterCategorizer(parameterSanitizer);
+        return new ParameterCategorizer(parameterSanitizer, streamPreservationMatcher);
     }
 
     Lifecycle buildLifecycle()
@@ -179,5 +184,10 @@ public class Builder
     public void init(RecordingReaderInterceptor interceptor)
     {
         interceptor.setFactory(buildRecorderFactory());
+    }
+
+    public void setEntityStreamPreservationMatcher(RequestMatcher matcher)
+    {
+        streamPreservationMatcher.replace(matcher);
     }
 }

--- a/src/main/java/org/cru/redegg/manual/ReplaceableRequestMatcher.java
+++ b/src/main/java/org/cru/redegg/manual/ReplaceableRequestMatcher.java
@@ -1,0 +1,30 @@
+package org.cru.redegg.manual;
+
+import org.cru.redegg.recording.api.RequestMatcher;
+
+import javax.servlet.ServletRequest;
+
+/**
+ * @author Matt Drees
+ */
+public class ReplaceableRequestMatcher implements RequestMatcher
+{
+    private volatile RequestMatcher delegate;
+
+    public ReplaceableRequestMatcher(RequestMatcher initialDelegate)
+    {
+        this.delegate = initialDelegate;
+    }
+
+
+    public void replace(RequestMatcher newDelegate)
+    {
+        delegate = newDelegate;
+    }
+
+    @Override
+    public boolean matches(ServletRequest request)
+    {
+        return delegate.matches(request);
+    }
+}

--- a/src/main/java/org/cru/redegg/qualifier/EntityStreamPreservation.java
+++ b/src/main/java/org/cru/redegg/qualifier/EntityStreamPreservation.java
@@ -1,0 +1,16 @@
+package org.cru.redegg.qualifier;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * @author Matt Drees
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface EntityStreamPreservation
+{
+}

--- a/src/main/java/org/cru/redegg/recording/api/RedEgg.java
+++ b/src/main/java/org/cru/redegg/recording/api/RedEgg.java
@@ -3,6 +3,8 @@ package org.cru.redegg.recording.api;
 import org.cru.redegg.manual.Builder;
 import org.cru.redegg.reporting.errbit.ErrbitConfig;
 
+import javax.servlet.ServletRequest;
+
 /**
  * If you are not using CDI, use this class to configure Red Egg and to obtain a RecorderFactory
  *
@@ -57,6 +59,16 @@ public class RedEgg
     public RedEgg setEntitySanitizer(EntitySanitizer sanitizer)
     {
         builder.setEntitySanitizer(sanitizer);
+        return this;
+    }
+
+    /**
+     * Configures a matcher that identifies which request must retain the ability to call
+     * {@link ServletRequest#getInputStream()} and {@link ServletRequest#getReader()}.
+     */
+    public RedEgg setEntityStreamPreservationMatcher(RequestMatcher matcher)
+    {
+        builder.setEntityStreamPreservationMatcher(matcher);
         return this;
     }
 }

--- a/src/main/java/org/cru/redegg/recording/api/RequestMatcher.java
+++ b/src/main/java/org/cru/redegg/recording/api/RequestMatcher.java
@@ -1,0 +1,18 @@
+package org.cru.redegg.recording.api;
+
+import javax.servlet.ServletRequest;
+import java.util.regex.Matcher;
+
+/**
+ * Somewhat like a watered-down regular expression {@link Matcher},
+ * this is an object that determines whether a given {@link ServletRequest}
+ * matches a set of criteria.
+ *
+ * See {@link RequestMatchers} for creating concrete matchers.
+ *
+ * @author Matt Drees
+ */
+public interface RequestMatcher
+{
+    boolean matches(ServletRequest request);
+}

--- a/src/main/java/org/cru/redegg/recording/api/RequestMatchers.java
+++ b/src/main/java/org/cru/redegg/recording/api/RequestMatchers.java
@@ -1,0 +1,102 @@
+package org.cru.redegg.recording.api;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import org.cru.redegg.qualifier.EntityStreamPreservation;
+import org.cru.redegg.qualifier.Fallback;
+
+import javax.enterprise.inject.Produces;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/**
+ * @author Matt Drees
+ */
+public class RequestMatchers
+{
+    /**
+     * Returns a matcher that matches a request if
+     * its servlet path and servlet info path together match one of the given regular expressions.
+     *
+     * <p>
+     * For example, the following will create matcher that matches any jsp requests and
+     * any requests to a servlet mapped to {@code /rest-api/*}:
+     *
+     * <pre> {@code
+     *   RequestMatcher.matchingPaths(Arrays.asList(
+     *     ".*\.jsp",
+     *     "/rest-api/.*");
+     * } </pre>
+     *
+     *
+     * @param pathExpressions one or more regular expressions
+     */
+    public static RequestMatcher matchingPaths(Iterable<String> pathExpressions)
+    {
+        String combinedExpression = Joiner.on("|").join(pathExpressions);
+        return new PathRequestMatcher(Pattern.compile(combinedExpression));
+    }
+
+    /**
+     * A convenience shortcut for {@link #matchingPaths(Iterable)},
+     * for use when the set of expressions can be hardcoded.
+     */
+    public static RequestMatcher matchingPaths(String... pathExpressions)
+    {
+        return matchingPaths(Arrays.asList(pathExpressions));
+    }
+
+    /**
+     * Returns a matcher that will not match any requests.
+     */
+    @Produces
+    @Fallback @EntityStreamPreservation
+    public static RequestMatcher none()
+    {
+        return new RequestMatcher()
+        {
+            @Override
+            public boolean matches(ServletRequest request)
+            {
+                return false;
+            }
+        };
+    }
+
+
+    private static class PathRequestMatcher implements RequestMatcher
+    {
+        private final Pattern urlPattern;
+
+        private PathRequestMatcher(Pattern urlPattern)
+        {
+            this.urlPattern = urlPattern;
+        }
+
+        public boolean matches(ServletRequest request)
+        {
+            Preconditions.checkNotNull(request, "request is null");
+            if (request instanceof HttpServletRequest)
+            {
+                HttpServletRequest httpRequest = (HttpServletRequest) request;
+                String fullPath = getFullPath(httpRequest);
+                if (urlPattern.matcher(fullPath).matches())
+                    return true;
+            }
+            return false;
+        }
+
+        private String getFullPath(HttpServletRequest httpRequest)
+        {
+            String servletPath = httpRequest.getServletPath();
+            servletPath = servletPath == null ? "" : servletPath;
+            String pathInfo = httpRequest.getPathInfo();
+            pathInfo = pathInfo == null ? "" : pathInfo;
+            return servletPath + pathInfo;
+        }
+
+    }
+
+}

--- a/src/main/java/org/cru/redegg/recording/cdi/RequestMatcherProducer.java
+++ b/src/main/java/org/cru/redegg/recording/cdi/RequestMatcherProducer.java
@@ -1,0 +1,31 @@
+package org.cru.redegg.recording.cdi;
+
+import org.cru.redegg.qualifier.EntityStreamPreservation;
+import org.cru.redegg.qualifier.Fallback;
+import org.cru.redegg.qualifier.Selected;
+import org.cru.redegg.recording.api.RequestMatcher;
+
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+
+/**
+ * @author Matt Drees
+ */
+public class RequestMatcherProducer
+{
+    public
+    @Produces
+    @Selected
+    @EntityStreamPreservation
+    RequestMatcher selectParameterSanitizer(
+        @Default @EntityStreamPreservation Instance<RequestMatcher> defaultSanitizer,
+        @Fallback @EntityStreamPreservation RequestMatcher fallbackSanitizer)
+    {
+        if (!defaultSanitizer.isUnsatisfied())
+            return defaultSanitizer.get();
+        else
+            return fallbackSanitizer;
+    }
+
+}

--- a/src/main/java/org/cru/redegg/recording/cdi/RequestMatcherProducer.java
+++ b/src/main/java/org/cru/redegg/recording/cdi/RequestMatcherProducer.java
@@ -18,14 +18,14 @@ public class RequestMatcherProducer
     @Produces
     @Selected
     @EntityStreamPreservation
-    RequestMatcher selectParameterSanitizer(
-        @Default @EntityStreamPreservation Instance<RequestMatcher> defaultSanitizer,
-        @Fallback @EntityStreamPreservation RequestMatcher fallbackSanitizer)
+    RequestMatcher selectEntityStreamPreservationRequestMatcher(
+        @Default @EntityStreamPreservation Instance<RequestMatcher> defaultMatcher,
+        @Fallback @EntityStreamPreservation RequestMatcher fallbackMatcher)
     {
-        if (!defaultSanitizer.isUnsatisfied())
-            return defaultSanitizer.get();
+        if (!defaultMatcher.isUnsatisfied())
+            return defaultMatcher.get();
         else
-            return fallbackSanitizer;
+            return fallbackMatcher;
     }
 
 }

--- a/src/main/java/org/cru/redegg/servlet/RedEggServletListener.java
+++ b/src/main/java/org/cru/redegg/servlet/RedEggServletListener.java
@@ -9,6 +9,7 @@ import org.cru.redegg.recording.api.ParameterSanitizer;
 import org.cru.redegg.recording.api.RecorderFactory;
 import org.cru.redegg.recording.api.WebErrorRecorder;
 import org.cru.redegg.util.Clock;
+import org.joda.time.DateTime;
 
 import javax.inject.Inject;
 import javax.servlet.ServletContextEvent;
@@ -68,10 +69,12 @@ public class RedEggServletListener implements ServletContextListener, ServletReq
 
     private void requestInitialized(HttpServletRequest request)
     {
+        // capture the current time as early as possible
+        DateTime requestStart = clock.dateTime();
+
         lifecycle.beginRequest();
         WebErrorRecorder recorder = recorderFactory.getWebRecorder()
-            // capture the current time as early as possible
-            .recordRequestStart(clock.dateTime())
+            .recordRequestStart(requestStart)
             .recordRequestUrl(request.getRequestURL().toString())
             .recordRequestMethod(request.getMethod())
             .recordHeaders(getHeadersAsMultimap(request));

--- a/src/test/java/org/cru/redegg/JaxrsRecordingIntegrationTest.java
+++ b/src/test/java/org/cru/redegg/JaxrsRecordingIntegrationTest.java
@@ -63,8 +63,6 @@ public class JaxrsRecordingIntegrationTest
 
             .addClass(TestApplication.class)
             .addClass(WebTargetBuilder.class)
-            .addClass(Fruit.class)
-            .addClass(FruitResource.class)
             .addClass(AnswerWithSelf.class)
             .addClass(RecordingMocks.class)
            ;

--- a/src/test/java/org/cru/redegg/JaxwsRecordingIntegrationTest.java
+++ b/src/test/java/org/cru/redegg/JaxwsRecordingIntegrationTest.java
@@ -51,7 +51,7 @@ public class JaxwsRecordingIntegrationTest
 
         return DefaultDeployment.withCdi("jaxws-test.war")
             .addCorePackages()
-            .addRecordingSanitizerClasses()
+            .addRecordingConfigurationClasses()
             .getArchive()
 
             .addPackage(RecordingSoapHandler.class.getPackage())

--- a/src/test/java/org/cru/redegg/JaxwsRecordingIntegrationTest.java
+++ b/src/test/java/org/cru/redegg/JaxwsRecordingIntegrationTest.java
@@ -61,9 +61,6 @@ public class JaxwsRecordingIntegrationTest
 
             .addClass(TestApplication.class)
             .addClass(PortBuilder.class)
-            .addClass(Fruit.class)
-            .addClass(FruitService.class)
-            .addClass(FruitServiceImpl.class)
             .addClass(AnswerWithSelf.class)
             .addClass(RecordingMocks.class)
 

--- a/src/test/java/org/cru/redegg/RedEggAppenderIntegrationTest.java
+++ b/src/test/java/org/cru/redegg/RedEggAppenderIntegrationTest.java
@@ -35,7 +35,7 @@ public class RedEggAppenderIntegrationTest
     public static WebArchive deployment()  {
 
         return DefaultDeployment.withCdi()
-            .addRecordingSanitizerClasses()
+            .addRecordingConfigurationClasses()
             .getArchive()
             .addClass(RedEggServletListener.class)
             .addClass(ParameterCategorizer.class)

--- a/src/test/java/org/cru/redegg/test/DefaultDeployment.java
+++ b/src/test/java/org/cru/redegg/test/DefaultDeployment.java
@@ -3,6 +3,7 @@ package org.cru.redegg.test;
 import org.cru.redegg.boot.Lifecycle;
 import org.cru.redegg.qualifier.Selected;
 import org.cru.redegg.recording.api.RecorderFactory;
+import org.cru.redegg.recording.cdi.RequestMatcherProducer;
 import org.cru.redegg.recording.cdi.SanitizerProducer;
 import org.cru.redegg.recording.impl.HyperConservativeEntitySanitizer;
 import org.cru.redegg.recording.impl.HyperConservativeParameterSanitizer;
@@ -160,11 +161,12 @@ public class DefaultDeployment {
         return RedEggAppender.class.getPackage();
     }
 
-    public DefaultDeployment addRecordingSanitizerClasses()
+    public DefaultDeployment addRecordingConfigurationClasses()
     {
         getArchive()
             .addClass(HyperConservativeEntitySanitizer.class)
             .addClass(HyperConservativeParameterSanitizer.class)
+            .addClass(RequestMatcherProducer.class)
             .addClass(SanitizerProducer.class);
         return this;
     }


### PR DESCRIPTION
This PR allows an app to use `ServletRequest.getInputStream()`, which was previously not possible.

The builds on #11, so the first commit here is actually af01cfcb8fd3c22f2cb3d250838495315fa3a8d8. I will rebase once #11 is merged.