### PR TITLE
Don't consume arbitrary memory for badly performing requests

### DIFF
--- a/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
+++ b/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
@@ -33,6 +33,7 @@ import java.util.logging.SimpleFormatter;
  */
 public class DefaultErrorRecorder implements ErrorRecorder {
 
+    private static final int LOG_RECORD_LIMIT = 100;
     private ErrorQueue queue;
     private Serializer serializer;
 
@@ -92,7 +93,8 @@ public class DefaultErrorRecorder implements ErrorRecorder {
         checkNotSent();
         if (logRecords == null)
             logRecords = Lists.newLinkedList();
-        logRecords.add(record);
+        if (logRecords.size() < LOG_RECORD_LIMIT)
+            logRecords.add(record);
         if (isErrorLog(record) && isNotIgnored(record.getLoggerName()))
         {
             if (record.getThrown() != null)

--- a/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
+++ b/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
@@ -302,6 +302,13 @@ public class DefaultErrorRecorder implements ErrorRecorder {
                 simplifier.restoreOriginalStacktraces();
             }
         }
+        if (logRecords.size() == LOG_RECORD_LIMIT)
+        {
+            serializedLogRecords.add(
+                "<limit of " +
+                LOG_RECORD_LIMIT +
+                " was reached; any further log records were not recorded>");
+        }
         return serializedLogRecords;
     }
 


### PR DESCRIPTION
This addresses a problem that was raised a few days ago by some badly-behaving Wsapi code (see Cru-Tech/wsapi/pull/70). 