### PR TITLE
Make environment variables and system properties NOT passed by default

### DIFF
--- a/src/main/java/org/cru/redegg/recording/api/ErrorRecorder.java
+++ b/src/main/java/org/cru/redegg/recording/api/ErrorRecorder.java
@@ -25,7 +25,9 @@ public interface ErrorRecorder {
 
     ErrorRecorder ignoreErrorsFromLogger(String loggerName);
 
+    ErrorRecorder includeEnvironmentVariables(boolean includeEnvironmentVariables);
 
+    ErrorRecorder includeSystemProperties(boolean includeSystemProperties);
     /**
      * indicates that this the error recorded (if any) was definitely the user/client's fault.
      *

--- a/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
+++ b/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
@@ -42,7 +42,9 @@ public class DefaultErrorRecorder implements ErrorRecorder {
     private LinkedHashSet<Throwable> thrown;
     private LinkedList<LogRecord> logRecords;
     private InetAddress localHost;
+    private boolean includeEnvironmentVariables = false;
     private Map<String, String> environmentVariables;
+    private boolean includeSystemProperties = false;
     private Properties systemProperties;
     private Set<String> loggersToIgnore;
 
@@ -119,6 +121,7 @@ public class DefaultErrorRecorder implements ErrorRecorder {
     public ErrorRecorder recordSystemProperties(Properties systemProperties) {
         checkNotSent();
         this.systemProperties = systemProperties;
+        this.includeSystemProperties = true;
         return this;
     }
 
@@ -126,6 +129,23 @@ public class DefaultErrorRecorder implements ErrorRecorder {
     public ErrorRecorder recordEnvironmentVariables(Map<String, String> variables) {
         checkNotSent();
         this.environmentVariables = variables;
+        this.includeEnvironmentVariables = true;
+        return this;
+    }
+
+    @Override
+    public ErrorRecorder includeEnvironmentVariables(boolean includeEnvironmentVariables)
+    {
+        checkNotSent();
+        this.includeEnvironmentVariables = includeEnvironmentVariables;
+        return this;
+    }
+
+    @Override
+    public ErrorRecorder includeSystemProperties(boolean includeSystemProperties)
+    {
+        checkNotSent();
+        this.includeSystemProperties = includeSystemProperties;
         return this;
     }
 
@@ -177,7 +197,7 @@ public class DefaultErrorRecorder implements ErrorRecorder {
     public void addAdditionalContextIfPossible()
     {
         addLocalHost();
-        if (systemProperties == null)
+        if (includeSystemProperties && systemProperties == null)
         {
             try
             {
@@ -187,7 +207,7 @@ public class DefaultErrorRecorder implements ErrorRecorder {
             {
             }
         }
-        if (environmentVariables == null)
+        if (includeEnvironmentVariables && environmentVariables == null)
         {
             try
             {


### PR DESCRIPTION
It's not generally known what data are stored in properties and environment variables, so it should be up to the developer on a given project whether or not to include them.  The new default behavior is that developers must opt in to including these in error reports.

It should be noted that calling the explicit `recordSystemProperties` and `recordEnvironmentVariables` methods on `ErrorRecorder` is an opt-in and sets the respective boolean to true for correctness.