### PR TITLE
Disable environment variable reporting by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,16 @@ You can optionally record additional context information that will make your err
 Inject a WebErrorRecorder into an appropriate class (likely an interceptor or decorator),
 and use the `recordContext()` and/or `recordUser()` methods.
 
+You may wish to record the JVM's environment variables; use `recordEnvironmentVariables()` for this.
+They are not recorded automatically, since (at least in Docker apps) they often contain credentials.
+You can, of course, sanitize the values before recording them, but Red Egg doesn't do this for you.
+
+System properties, on the other hand, are recorded automatically.
+If you wish to disable this, call `recordSystemProperties()` with an empty map.
+(Or you may sanitize the properties and then record them.)
+
+The hostname is recorded automatically, but you can override it with `recordLocalHost()`.
+
 
 Building this project
 =====================

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <version.arquillian_core>1.1.2.Final</version.arquillian_core>
-    <wildfly.arquillian.version>8.0.0.Final</wildfly.arquillian.version>
+    <wildfly.arquillian.version>8.2.1.Final</wildfly.arquillian.version>
     <jboss.as.arquillian.version>7.2.0.Final</jboss.as.arquillian.version>
     <resteasy.version>3.0.5.Final</resteasy.version>
 
@@ -270,7 +270,7 @@
           <plugin>
             <groupId>org.wildfly.plugins</groupId>
             <artifactId>wildfly-maven-plugin</artifactId>
-            <version>1.0.1.Final</version>
+            <version>1.0.2.Final</version>
             <configuration>
               <version>${wildfly.arquillian.version}</version>
               <jvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -2,14 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.ccci</groupId>
-    <artifactId>ccci-root</artifactId>
-    <version>2</version>
-  </parent>
-
+  <groupId>org.ccci</groupId>
   <artifactId>red-egg</artifactId>
   <version>2-SNAPSHOT</version>
 
@@ -21,6 +16,7 @@
     <resteasy.version>3.0.5.Final</resteasy.version>
 
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
 
@@ -337,6 +333,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>2.4</version>
         <executions>
           <execution>
             <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.ccci</groupId>
   <artifactId>red-egg</artifactId>
-  <version>2-SNAPSHOT</version>
+  <version>2</version>
 
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,10 @@
 
 
   <properties>
-    <version.arquillian_core>1.1.2.Final</version.arquillian_core>
+    <version.arquillian_core>1.1.10.Final</version.arquillian_core>
     <wildfly.arquillian.version>8.2.1.Final</wildfly.arquillian.version>
     <jboss.as.arquillian.version>7.2.0.Final</jboss.as.arquillian.version>
-    <resteasy.version>3.0.5.Final</resteasy.version>
+    <resteasy.version>3.0.12.Final</resteasy.version>
 
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
+++ b/src/main/java/org/cru/redegg/recording/impl/DefaultErrorRecorder.java
@@ -187,16 +187,6 @@ public class DefaultErrorRecorder implements ErrorRecorder {
             {
             }
         }
-        if (environmentVariables == null)
-        {
-            try
-            {
-                environmentVariables = System.getenv();
-            }
-            catch (SecurityException ignored)
-            {
-            }
-        }
     }
 
     private void addLocalHost()

--- a/src/test/java/org/cru/redegg/JaxrsRecordingIntegrationTest.java
+++ b/src/test/java/org/cru/redegg/JaxrsRecordingIntegrationTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
@@ -151,7 +152,16 @@ public class JaxrsRecordingIntegrationTest
         assertThat(response.getStatus(), equalTo(200));
 
         verify(recorder).recordEntityRepresentation(anyString());
-        verify(recorder).recordRequestPostParameters(ImmutableMultimap.<String, String>of());
+
+        ImmutableMultimap<String, String> expected = ImmutableMultimap.of();
+        /* Note: it would be nice to verify this happen occurred exactly once,
+         * but unfortunately arquillian occasionally makes its own POST requests
+         * (with no post parameters) to the ArquillianServletRunner during test executions.
+         * This causes the recorder to record more than one request,
+         * which would fail that verification.
+         * So, we use atLeastOnce() which is good enough.
+         */
+        verify(recorder, atLeastOnce()).recordRequestPostParameters(expected);
     }
 
     @Test
@@ -192,7 +202,8 @@ public class JaxrsRecordingIntegrationTest
         verify(recorder).recordEntityRepresentation(anyString());
 
         Multimap<String, String> expected = ImmutableMultimap.of();
-        verify(recorder).recordRequestPostParameters(expected);
+        // See note in testSimpleJsonJaxrsPostJsonRequest()
+        verify(recorder, atLeastOnce()).recordRequestPostParameters(expected);
     }
 
     private WebTarget getWebTarget()

--- a/src/test/java/org/cru/redegg/it/DummyErrbitApi.java
+++ b/src/test/java/org/cru/redegg/it/DummyErrbitApi.java
@@ -13,15 +13,17 @@ public class DummyErrbitApi
     volatile static String report;
 
     @POST
-    public void postNotice(String xmlPayload)
+    public synchronized void postNotice(String xmlPayload)
     {
         report = xmlPayload;
     }
 
     @GET
-    public String getMostRecentReport()
+    public synchronized String getMostRecentReport()
     {
-        return report;
+        String returnedReport = report;
+        report = null;
+        return returnedReport;
     }
 
 }


### PR DESCRIPTION
We're increasingly using environment variables pass in passwords. So, don't record all environment variables by default. 

[MISC-219](https://jira.cru.org/browse/MISC-219)

This PR also includes a few version updates and fixes two tests that were failing on the CI server.