### PR TITLE
Add Asynchronous Filter Support

### DIFF
--- a/src/main/java/org/cru/redegg/servlet/RedEggFilter.java
+++ b/src/main/java/org/cru/redegg/servlet/RedEggFilter.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 /**
  * @author Matt Drees
  */
-@WebFilter(urlPatterns = "/*")
+@WebFilter(urlPatterns = "/*", asyncSupported = true)
 public class RedEggFilter implements Filter {
 
     @Inject


### PR DESCRIPTION
Allows red-egg servlet filter to be used in context of an asynchronous servlet (https://docs.oracle.com/javaee/7/tutorial/servlets012.htm). 

@mattdrees 