### PR TITLE
handle RejectedExecutionExceptions in error report queue

### DIFF
--- a/src/main/java/org/cru/redegg/reporting/InMemoryErrorQueue.java
+++ b/src/main/java/org/cru/redegg/reporting/InMemoryErrorQueue.java
@@ -99,7 +99,6 @@ public class InMemoryErrorQueue implements ErrorQueue
         }
         catch (RejectedExecutionException e)
         {
-            System.out.println("submission rejected");
             errorLog.error("unable to submit error report to queue; using fallback reporter", e);
 
             // run on this thread
@@ -134,9 +133,7 @@ public class InMemoryErrorQueue implements ErrorQueue
     {
         try
         {
-            System.out.println("sending fallback");
             fallbackReporter.send(report);
-            System.out.println("sent fallback");
         }
         catch (Throwable t2)
         {

--- a/src/main/java/org/cru/redegg/reporting/api/ErrorQueue.java
+++ b/src/main/java/org/cru/redegg/reporting/api/ErrorQueue.java
@@ -7,6 +7,13 @@ import org.cru.redegg.reporting.ErrorReport;
  */
 public interface ErrorQueue {
 
+    /**
+     * Puts an error report in the queue to be reported asynchronously.
+     *
+     * This doesn't throw an exception if the queue is full,
+     * or if some other problem (a number-of-threads OME, for example)
+     * prevents the queue from taking an additional element.
+     */
     public void enqueue(ErrorReport report);
 
 }

--- a/src/test/java/org/cru/redegg/reporting/InMemoryErrorQueueTest.java
+++ b/src/test/java/org/cru/redegg/reporting/InMemoryErrorQueueTest.java
@@ -1,0 +1,70 @@
+package org.cru.redegg.reporting;
+
+import org.cru.redegg.reporting.api.ErrorReporter;
+import org.cru.redegg.util.ErrorLog;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Matt Drees
+ */
+public class InMemoryErrorQueueTest
+{
+    @Mock
+    ErrorReporter primaryErrorReporter;
+
+    @Mock
+    ErrorReporter fallbackReporter;
+
+    @Mock
+    ErrorLog errorLog;
+
+    @Mock
+    ExecutorService executorService;
+
+    InMemoryErrorQueue queue;
+
+    @Before
+    public void setup()
+    {
+        MockitoAnnotations.initMocks(this);
+        queue = new InMemoryErrorQueue(
+            primaryErrorReporter,
+            fallbackReporter,
+            errorLog,
+            executorService);
+    }
+
+    @Test
+    public void testEnqueue() throws Exception
+    {
+        queue.enqueue(new ErrorReport());
+
+        verify(executorService).submit(any(Runnable.class));
+        verify(errorLog, never()).error(anyString(), any(Throwable.class));
+    }
+
+    @Test
+    public void testEnqueueWhenExecutorServiceRejectsTask() throws Exception
+    {
+        when(executorService.submit(any(Runnable.class)))
+            .thenThrow(new RejectedExecutionException());
+
+        ErrorReport report = new ErrorReport();
+        queue.enqueue(report);
+
+        verify(fallbackReporter).send(report);
+        verify(errorLog).error(anyString(), any(Throwable.class));
+    }
+}


### PR DESCRIPTION
This gracefully handles cases where `InMemoryErrorQueue` cannot add a new report to the queue because the `ExecutorService` can't handle it.
Before, the `RejectedExecutionException` would propagate, and hide the original exception.

This happened a few weeks ago in the IDM apps,
when they began getting `java.lang.OutOfMemoryError: unable to create new native thread` failures.
(There were too many running threads on the OS, I believe.)
This caused `ExecutorService.submit()` to fail, and the original problem was not logged
(only the `RejectedExecutionException`).