### PR TITLE
Prevent rollbar-java's log.error() calls from triggering new rollbar reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.ccci</groupId>
   <artifactId>red-egg</artifactId>
-  <version>9</version>
+  <version>10-SNAPSHOT</version>
 
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.ccci</groupId>
   <artifactId>red-egg</artifactId>
-  <version>10-SNAPSHOT</version>
+  <version>10</version>
 
 
   <properties>

--- a/src/main/java/org/cru/redegg/boot/Lifecycle.java
+++ b/src/main/java/org/cru/redegg/boot/Lifecycle.java
@@ -26,7 +26,16 @@ public class Lifecycle
      */
     private final Set<String> ignoredLoggers = ImmutableSet.of(
         ErrorLog.name(),
-        LoggingReporter.name()
+        LoggingReporter.name(),
+
+        // TODO: It'd be be more architecturally clean for this to be added
+        // by some rollbar-specific code, but it'll do for now.
+        "com.rollbar.notifier.Rollbar",
+        "com.rollbar.notifier.sender.SyncSender",
+        "com.rollbar.notifier.sender.BufferedSender",
+        "com.rollbar.notifier.sender.queue.DiskQueue",
+        "com.rollbar.notifier.util.ObjectsUtils",
+        "ConfigProviderHelper" // used in com.rollbar.notifier.config.ConfigProviderHelper
     );
 
     @Inject


### PR DESCRIPTION
Rollbar-java now has internal slf4j logging that can be picked up by red-egg's appender-based collectors.
This caused a feedback loop in EP, and triggered millions of error logs, which killed our log quota for the day.
